### PR TITLE
Tuning log level

### DIFF
--- a/datafusion-ext/src/hdfs_object_store.rs
+++ b/datafusion-ext/src/hdfs_object_store.rs
@@ -14,7 +14,7 @@ use futures::AsyncRead;
 use jni::errors::Result as JniResult;
 use jni::objects::JObject;
 use jni::objects::JValue;
-use log::{debug, info};
+use log::{debug, info, trace};
 
 use crate::jni_bridge::JavaClasses;
 use crate::jni_bridge_call_method;
@@ -45,7 +45,7 @@ impl ObjectStore for HDFSSingleFileObjectStore {
     }
 
     fn file_reader(&self, file: SizedFile) -> Result<Arc<dyn ObjectReader>> {
-        info!("HDFSSingleFileStore.file_reader: {:?}", file);
+        trace!("HDFSSingleFileStore.file_reader: {:?}", file);
         let hdfs_input_stream = Arc::new(
             FSDataInputStreamWrapper::try_new(&file.path)
                 .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?,

--- a/datafusion-ext/src/hdfs_object_store.rs
+++ b/datafusion-ext/src/hdfs_object_store.rs
@@ -14,7 +14,7 @@ use futures::AsyncRead;
 use jni::errors::Result as JniResult;
 use jni::objects::JObject;
 use jni::objects::JValue;
-use log::{debug, info, trace};
+use log::{debug, trace};
 
 use crate::jni_bridge::JavaClasses;
 use crate::jni_bridge_call_method;

--- a/datafusion-ext/src/hdfs_object_store.rs
+++ b/datafusion-ext/src/hdfs_object_store.rs
@@ -14,7 +14,7 @@ use futures::AsyncRead;
 use jni::errors::Result as JniResult;
 use jni::objects::JObject;
 use jni::objects::JValue;
-use log::{debug, trace};
+use log::debug;
 
 use crate::jni_bridge::JavaClasses;
 use crate::jni_bridge_call_method;
@@ -45,7 +45,7 @@ impl ObjectStore for HDFSSingleFileObjectStore {
     }
 
     fn file_reader(&self, file: SizedFile) -> Result<Arc<dyn ObjectReader>> {
-        trace!("HDFSSingleFileStore.file_reader: {:?}", file);
+        debug!("HDFSSingleFileStore.file_reader: {:?}", file);
         let hdfs_input_stream = Arc::new(
             FSDataInputStreamWrapper::try_new(&file.path)
                 .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?,

--- a/datafusion-ext/src/jni_bridge.rs
+++ b/datafusion-ext/src/jni_bridge.rs
@@ -16,7 +16,7 @@ use jni::JavaVM;
 #[macro_export]
 macro_rules! jni_bridge_new_object {
     ($env:expr, $clsname:ident $(, $args:expr)*) => {{
-        log::info!("jni_bridge_new_object!({}, {:?})", stringify!($clsname), &[$($args,)*]);
+        log::trace!("jni_bridge_new_object!({}, {:?})", stringify!($clsname), &[$($args,)*]);
         $env.new_object_unchecked(
             paste::paste! {JavaClasses::get().[<c $clsname>].class},
             paste::paste! {JavaClasses::get().[<c $clsname>].ctor},
@@ -28,7 +28,7 @@ macro_rules! jni_bridge_new_object {
 #[macro_export]
 macro_rules! jni_bridge_call_method {
     ($env:expr, $clsname:ident . $method:ident, $obj:expr $(, $args:expr)*) => {{
-        log::info!("jni_bridge_call_method!({}.{}, {:?})",
+        log::trace!("jni_bridge_call_method!({}.{}, {:?})",
             stringify!($clsname),
             stringify!($method),
             &[$($args,)*] as &[JValue]);
@@ -44,7 +44,7 @@ macro_rules! jni_bridge_call_method {
 #[macro_export]
 macro_rules! jni_bridge_call_static_method {
     ($env:expr, $clsname:ident . $method:ident $(, $args:expr)*) => {{
-        log::info!("jni_bridge_call_static_method!({}.{}, {:?})",
+        log::trace!("jni_bridge_call_static_method!({}.{}, {:?})",
             stringify!($clsname),
             stringify!($method),
             &[$($args,)*] as &[JValue]);

--- a/datafusion-ext/src/shuffle_writer_exec.rs
+++ b/datafusion-ext/src/shuffle_writer_exec.rs
@@ -63,7 +63,7 @@ use datafusion::physical_plan::Statistics;
 use futures::lock::Mutex;
 use futures::StreamExt;
 use jni::{errors::Result as JniResult, objects::JValue};
-use log::info;
+use log::{debug, info};
 use tempfile::NamedTempFile;
 use tokio::task;
 
@@ -519,7 +519,7 @@ impl MemoryConsumer for ShuffleRepartitioner {
     }
 
     async fn spill(&self) -> Result<usize> {
-        info!(
+        debug!(
             "{}[{}] spilling shuffle data of {} to disk while inserting ({} time(s) so far)",
             self.name(),
             self.id(),
@@ -671,6 +671,7 @@ impl ShuffleWriterExec {
     }
 }
 
+// TODO: reconsider memory consumption for shuffle buffers, unrevealed usage?
 pub async fn external_shuffle(
     mut input: SendableRecordBatchStream,
     partition_id: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use jni::objects::JClass;
 use jni::objects::JObject;
 use jni::objects::JValue;
 use jni::JNIEnv;
-use log::{debug, info, trace};
+use log::{debug, info};
 use once_cell::sync::OnceCell;
 use plan_serde::protobuf::TaskDefinition;
 use prost::Message;
@@ -90,21 +90,21 @@ pub fn blaze_call_native(
     );
     info!("Blaze native computing started");
 
-    trace!("Initializing JavaClasses");
+    debug!("Initializing JavaClasses");
     JavaClasses::init(env).expect("Error initializing JavaClasses");
     let env = JavaClasses::get_thread_jnienv();
-    trace!("Initializing JavaClasses succeeded");
+    debug!("Initializing JavaClasses succeeded");
 
-    trace!("Decoding task definition");
+    debug!("Decoding task definition");
     let task_definition_raw = env
         .get_direct_buffer_address(task_definition)
         .expect("Error getting task definition");
     let task_definition: TaskDefinition =
         TaskDefinition::decode(&task_definition_raw[..])
             .expect("Error decoding task definition");
-    trace!("Decoding task definition succeeded");
+    debug!("Decoding task definition succeeded");
 
-    trace!("Creating native execution plan");
+    debug!("Creating native execution plan");
     let task_id = task_definition
         .task_id
         .expect("Missing task_definition.task_id");
@@ -182,7 +182,7 @@ pub fn blaze_call_native(
                 )
                 .unwrap();
 
-                trace!("Invoking IPC data consumer");
+                debug!("Invoking IPC data consumer");
                 let byte_buffer = env
                     .new_direct_byte_buffer(buf_writer.get_mut())
                     .expect("Error creating ByteBuffer");
@@ -193,11 +193,11 @@ pub fn blaze_call_native(
                     JValue::Object(byte_buffer.into())
                 )
                 .expect("Error invoking IPC data consumer");
-                trace!("Invoking IPC data consumer succeeded");
+                debug!("Invoking IPC data consumer succeeded");
             } else {
                 update_extra_metrics(&env, metric_node, start_time, 0, 0).unwrap();
 
-                trace!("Invoking IPC data consumer (with null result)");
+                debug!("Invoking IPC data consumer (with null result)");
                 jni_bridge_call_method!(
                     env,
                     JavaConsumer.accept,
@@ -205,7 +205,7 @@ pub fn blaze_call_native(
                     JValue::Object(JObject::null())
                 )
                 .expect("Error invoking IPC data consumer");
-                trace!("Invoking IPC data consumer succeeded");
+                debug!("Invoking IPC data consumer succeeded");
             }
         });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,12 +114,8 @@ pub fn blaze_call_native(
     let execution_plan: Arc<dyn ExecutionPlan> =
         plan.try_into().expect("Error converting to ExecutionPlan");
     info!(
-        "Creating native execution plan succeeded: task_id={:?}",
-        task_id
-    );
-
-    info!(
-        "Executing plan:\n{}",
+        "Creating native execution plan succeeded: task_id={:?}, execution plan:\n{}",
+        task_id,
         datafusion::physical_plan::displayable(execution_plan.as_ref()).indent()
     );
 


### PR DESCRIPTION
Left the followings `info!` untouched:

```rust
    info!(
        "shuffle write using data file: {}, index file: {}",
        &data_file, &index_file
    );

    info!(
        "blaze_call_native() time cost: {} sec",
        duration.as_secs_f64()
    );

    info!("Blaze native computing started");

    info!(
        "Creating native execution plan succeeded: task_id={:?}, execution plan:\n{}",
        task_id,
        datafusion::physical_plan::displayable(execution_plan.as_ref()).indent()
    );

    info!("Executing plan finished");

    info!(
        "Writing IPC finished: rows={}, bytes={}",
        num_rows_total,
        buf_writer.get_ref().len()
    );

    info!("Blaze native computing finished");

```